### PR TITLE
Features secure logging java8 date time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <version>1.18.38</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.4</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
+++ b/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
@@ -25,6 +25,8 @@ import com.techbulls.commons.securelog.annotation.SecureLog;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.WeakHashMap;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * <h2>SecureJson Class</h2>
@@ -127,6 +129,15 @@ public final class SecureJson {
      * @return the same {@link ObjectMapper} instance, now configured
      */
     private static ObjectMapper configureMapper(ObjectMapper m) {
+        // Auto-register Jackson modules if available
+        // (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
+        m.findAndRegisterModules();
+        // Explicitly support Java 8 date/time types
+        m.registerModule(new JavaTimeModule());
+        // Serialize dates as ISO strings instead of timestamps
+        m.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // Register secure serializer modifier
         SecureLogBeanSerializerModifier serializerModifier = new SecureLogBeanSerializerModifier();
         SerializerFactory serializerFactory = m.getSerializerFactory().withSerializerModifier(serializerModifier);
         m.setSerializerFactory(serializerFactory);

--- a/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
+++ b/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
@@ -129,7 +129,8 @@ public final class SecureJson {
      * @return the same {@link ObjectMapper} instance, now configured
      */
     private static ObjectMapper configureMapper(ObjectMapper m) {
-        // Auto-register Jackson modules if available (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
+        // Auto-register Jackson modules if available
+        // (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
         m.findAndRegisterModules();
         // Explicitly support Java 8 date/time types
         m.registerModule(new JavaTimeModule());

--- a/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
+++ b/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
@@ -129,8 +129,7 @@ public final class SecureJson {
      * @return the same {@link ObjectMapper} instance, now configured
      */
     private static ObjectMapper configureMapper(ObjectMapper m) {
-        // Auto-register Jackson modules if available
-        // (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
+        // Auto-register Jackson modules if available (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
         m.findAndRegisterModules();
         // Explicitly support Java 8 date/time types
         m.registerModule(new JavaTimeModule());


### PR DESCRIPTION
Fix LocalDateTime serialization support in secure logging library

Added `findAndRegisterModules()` to auto-register Jackson modules like `JavaTimeModule` for Java 8 date/time serialization support.