### PR TITLE
Fix LocalDateTime serialization support in secure logging library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
             <version>1.18.38</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.15.4</version>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
+++ b/src/main/java/com/techbulls/commons/securelog/serialization/SecureJson.java
@@ -25,6 +25,8 @@ import com.techbulls.commons.securelog.annotation.SecureLog;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.WeakHashMap;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * <h2>SecureJson Class</h2>
@@ -127,6 +129,12 @@ public final class SecureJson {
      * @return the same {@link ObjectMapper} instance, now configured
      */
     private static ObjectMapper configureMapper(ObjectMapper m) {
+        // Auto-register Jackson modules if available (JavaTimeModule, Jdk8Module, KotlinModule, etc.)
+        m.findAndRegisterModules();
+        m.registerModule(new JavaTimeModule());
+        // Serialize dates as ISO strings instead of timestamps
+        m.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
         SecureLogBeanSerializerModifier serializerModifier = new SecureLogBeanSerializerModifier();
         SerializerFactory serializerFactory = m.getSerializerFactory().withSerializerModifier(serializerModifier);
         m.setSerializerFactory(serializerFactory);

--- a/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
+++ b/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
@@ -1,0 +1,68 @@
+package com.techbulls.commons.securelog.serialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techbulls.commons.securelog.annotation.LogSensitive;
+import com.techbulls.commons.securelog.annotation.SecureLog;
+import lombok.Data;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class SecureJavaTimeModuleTest {
+
+    private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 15, 10, 30, 45);
+    private static final LocalDate BIRTH_DATE = LocalDate.of(1998, 1, 20);
+    private static final LocalTime LOGIN_TIME = LocalTime.of(9, 15, 10);
+
+    @Test
+    public void testJavaTimeSerializationWithDefaultMapper() throws JsonProcessingException {
+        JsonNode node = TestUtils.asJsonNode(SecureJson.toJson(buildPojo()));
+        assertTimeFields(node);
+        assertEquals("XXXX", node.get("secret").asText());
+    }
+
+    @Test
+    public void testJavaTimeSerializationWithCustomMapper() throws JsonProcessingException {
+        JsonNode node = TestUtils.asJsonNode(
+                SecureJson.toJson(new ObjectMapper(), buildPojo(), false, SecureLog.Default.class)
+        );
+        assertTimeFields(node);
+        assertEquals("XXXX", node.get("secret").asText());
+    }
+
+    private void assertTimeFields(JsonNode node) {
+        assertNotNull(node.get("createdAt"));
+        assertNotNull(node.get("birthDate"));
+        assertNotNull(node.get("loginTime"));
+        assertEquals("2026-05-15T10:30:45", node.get("createdAt").asText());
+        assertEquals("1998-01-20", node.get("birthDate").asText());
+        assertEquals("09:15:10", node.get("loginTime").asText());
+    }
+
+    private JavaTimePojo buildPojo() {
+        JavaTimePojo pojo = new JavaTimePojo();
+        pojo.setName("Test User");
+        pojo.setCreatedAt(CREATED_AT);
+        pojo.setBirthDate(BIRTH_DATE);
+        pojo.setLoginTime(LOGIN_TIME);
+        pojo.setSecret("my-secret");
+        return pojo;
+    }
+
+    @Data
+    @SecureLog
+    public static class JavaTimePojo {
+        private String name;
+        private LocalDateTime createdAt;
+        private LocalDate birthDate;
+        private LocalTime loginTime;
+        @LogSensitive private String secret;
+    }
+}

--- a/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
+++ b/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -18,51 +19,100 @@ import static org.junit.Assert.assertNotNull;
 public class SecureJavaTimeModuleTest {
 
     private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 15, 10, 30, 45);
-    private static final LocalDate BIRTH_DATE = LocalDate.of(1998, 1, 20);
-    private static final LocalTime LOGIN_TIME = LocalTime.of(9, 15, 10);
+    private static final LocalDate    BIRTH_DATE  = LocalDate.of(1998, 1, 20);
+    private static final LocalTime    LOGIN_TIME  = LocalTime.of(9, 15, 10);
+
+    // ── Default mapper ────────────────────────────────────────────────────────
+    @Test
+    public void testNonsensitiveTimeFields_DefaultMapper() throws JsonProcessingException {
+        JsonNode node = toNode(SecureJson.toJson(buildNonsensitivePojo()));
+        assertNonsensitiveTimeFields(node);
+        assertMasked(node, "secret");
+    }
+
+    // ── Custom mapper ─────────────────────────────────────────────────────────
+    @Test
+    public void testSensitiveTimeFields_CustomMapper() throws JsonProcessingException {
+        JsonNode node = toNode(SecureJson.toJson(new ObjectMapper(), buildSensitivePojo(), false, SecureLog.Default.class));
+        assertSensitiveTimeFields(node);
+        assertMasked(node, "secret");
+    }
 
     @Test
-    public void testJavaTimeSerializationWithDefaultMapper() throws JsonProcessingException {
-        JsonNode node = TestUtils.asJsonNode(SecureJson.toJson(buildPojo()));
-        assertTimeFields(node);
-        assertEquals("XXXX", node.get("secret").asText());
+    public void testNonsensitiveTimeFields_CustomMapper() throws JsonProcessingException {
+        JsonNode node = toNode(SecureJson.toJson(new ObjectMapper(), buildNonsensitivePojo(), false, SecureLog.Default.class));
+        assertNonsensitiveTimeFields(node);
+        assertMasked(node, "secret");
     }
 
-    @Test
-    public void testJavaTimeSerializationWithCustomMapper() throws JsonProcessingException {
-        JsonNode node = TestUtils.asJsonNode(
-                SecureJson.toJson(new ObjectMapper(), buildPojo(), false, SecureLog.Default.class)
-        );
-        assertTimeFields(node);
-        assertEquals("XXXX", node.get("secret").asText());
+    // ── Assertions ────────────────────────────────────────────────────────────
+    private void assertSensitiveTimeFields(JsonNode node) {
+        assertMasked(node, "createdAt");
+        assertMasked(node, "birthDate");
+        assertMasked(node, "loginTime");
     }
 
-    private void assertTimeFields(JsonNode node) {
-        assertNotNull(node.get("createdAt"));
-        assertNotNull(node.get("birthDate"));
-        assertNotNull(node.get("loginTime"));
-        assertEquals("2026-05-15T10:30:45", node.get("createdAt").asText());
-        assertEquals("1998-01-20", node.get("birthDate").asText());
-        assertEquals("09:15:10", node.get("loginTime").asText());
+    private void assertNonsensitiveTimeFields(JsonNode node) {
+        assertField(node, "createdAt", "2026-05-15T10:30:45");
+        assertField(node, "birthDate", "1998-01-20");
+        assertField(node, "loginTime", "09:15:10");
     }
 
-    private JavaTimePojo buildPojo() {
-        JavaTimePojo pojo = new JavaTimePojo();
-        pojo.setName("Test User");
-        pojo.setCreatedAt(CREATED_AT);
-        pojo.setBirthDate(BIRTH_DATE);
-        pojo.setLoginTime(LOGIN_TIME);
-        pojo.setSecret("my-secret");
+    private void assertMasked(JsonNode node, String field) {
+        assertField(node, field, "XXXX");
+    }
+
+    private void assertField(JsonNode node, String field, String expected) {
+        assertNotNull("Field missing: " + field, node.get(field));
+        assertEquals(expected, node.get(field).asText());
+    }
+
+    // ── Builders ──────────────────────────────────────────────────────────────
+    private JavaTimePojoWithSensitiveDateAndTime buildSensitivePojo() {
+        JavaTimePojoWithSensitiveDateAndTime pojo = new JavaTimePojoWithSensitiveDateAndTime();
+        populateCommonFields(pojo::setName, pojo::setCreatedAt, pojo::setBirthDate, pojo::setLoginTime, pojo::setSecret);
         return pojo;
     }
 
-    @Data
-    @SecureLog
-    public static class JavaTimePojo {
+    private JavaTimePojoWithNonsensitiveDateAndTime buildNonsensitivePojo() {
+        JavaTimePojoWithNonsensitiveDateAndTime pojo = new JavaTimePojoWithNonsensitiveDateAndTime();
+        populateCommonFields(pojo::setName, pojo::setCreatedAt, pojo::setBirthDate, pojo::setLoginTime, pojo::setSecret);
+        return pojo;
+    }
+
+    private void populateCommonFields(
+            Consumer<String> setName,
+            Consumer<LocalDateTime> setCreatedAt,
+            Consumer<LocalDate>     setBirthDate,
+            Consumer<LocalTime>     setLoginTime,
+            Consumer<String>        setSecret
+    ) {
+        setName.accept("Test User");
+        setCreatedAt.accept(CREATED_AT);
+        setBirthDate.accept(BIRTH_DATE);
+        setLoginTime.accept(LOGIN_TIME);
+        setSecret.accept("my-secret");
+    }
+
+    @Data @SecureLog
+    public static class JavaTimePojoWithSensitiveDateAndTime {
         private String name;
+        @LogSensitive private LocalDateTime createdAt;
+        @LogSensitive private LocalDate     birthDate;
+        @LogSensitive private LocalTime     loginTime;
+        @LogSensitive private String        secret;
+    }
+
+    @Data @SecureLog
+    public static class JavaTimePojoWithNonsensitiveDateAndTime {
+        private String        name;
         private LocalDateTime createdAt;
-        private LocalDate birthDate;
-        private LocalTime loginTime;
+        private LocalDate     birthDate;
+        private LocalTime     loginTime;
         @LogSensitive private String secret;
+    }
+
+    private JsonNode toNode(String json) throws JsonProcessingException {
+        return TestUtils.asJsonNode(json);
     }
 }

--- a/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
+++ b/src/test/java/com/techbulls/commons/securelog/serialization/SecureJavaTimeModuleTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -19,100 +18,51 @@ import static org.junit.Assert.assertNotNull;
 public class SecureJavaTimeModuleTest {
 
     private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 15, 10, 30, 45);
-    private static final LocalDate    BIRTH_DATE  = LocalDate.of(1998, 1, 20);
-    private static final LocalTime    LOGIN_TIME  = LocalTime.of(9, 15, 10);
+    private static final LocalDate BIRTH_DATE = LocalDate.of(1998, 1, 20);
+    private static final LocalTime LOGIN_TIME = LocalTime.of(9, 15, 10);
 
-    // ── Default mapper ────────────────────────────────────────────────────────
     @Test
-    public void testNonsensitiveTimeFields_DefaultMapper() throws JsonProcessingException {
-        JsonNode node = toNode(SecureJson.toJson(buildNonsensitivePojo()));
-        assertNonsensitiveTimeFields(node);
-        assertMasked(node, "secret");
-    }
-
-    // ── Custom mapper ─────────────────────────────────────────────────────────
-    @Test
-    public void testSensitiveTimeFields_CustomMapper() throws JsonProcessingException {
-        JsonNode node = toNode(SecureJson.toJson(new ObjectMapper(), buildSensitivePojo(), false, SecureLog.Default.class));
-        assertSensitiveTimeFields(node);
-        assertMasked(node, "secret");
+    public void testJavaTimeSerializationWithDefaultMapper() throws JsonProcessingException {
+        JsonNode node = TestUtils.asJsonNode(SecureJson.toJson(buildPojo()));
+        assertTimeFields(node);
+        assertEquals("XXXX", node.get("secret").asText());
     }
 
     @Test
-    public void testNonsensitiveTimeFields_CustomMapper() throws JsonProcessingException {
-        JsonNode node = toNode(SecureJson.toJson(new ObjectMapper(), buildNonsensitivePojo(), false, SecureLog.Default.class));
-        assertNonsensitiveTimeFields(node);
-        assertMasked(node, "secret");
+    public void testJavaTimeSerializationWithCustomMapper() throws JsonProcessingException {
+        JsonNode node = TestUtils.asJsonNode(
+                SecureJson.toJson(new ObjectMapper(), buildPojo(), false, SecureLog.Default.class)
+        );
+        assertTimeFields(node);
+        assertEquals("XXXX", node.get("secret").asText());
     }
 
-    // ── Assertions ────────────────────────────────────────────────────────────
-    private void assertSensitiveTimeFields(JsonNode node) {
-        assertMasked(node, "createdAt");
-        assertMasked(node, "birthDate");
-        assertMasked(node, "loginTime");
+    private void assertTimeFields(JsonNode node) {
+        assertNotNull(node.get("createdAt"));
+        assertNotNull(node.get("birthDate"));
+        assertNotNull(node.get("loginTime"));
+        assertEquals("XXXX", node.get("createdAt").asText());
+        assertEquals("1998-01-20", node.get("birthDate").asText());
+        assertEquals("09:15:10", node.get("loginTime").asText());
     }
 
-    private void assertNonsensitiveTimeFields(JsonNode node) {
-        assertField(node, "createdAt", "2026-05-15T10:30:45");
-        assertField(node, "birthDate", "1998-01-20");
-        assertField(node, "loginTime", "09:15:10");
-    }
-
-    private void assertMasked(JsonNode node, String field) {
-        assertField(node, field, "XXXX");
-    }
-
-    private void assertField(JsonNode node, String field, String expected) {
-        assertNotNull("Field missing: " + field, node.get(field));
-        assertEquals(expected, node.get(field).asText());
-    }
-
-    // ── Builders ──────────────────────────────────────────────────────────────
-    private JavaTimePojoWithSensitiveDateAndTime buildSensitivePojo() {
-        JavaTimePojoWithSensitiveDateAndTime pojo = new JavaTimePojoWithSensitiveDateAndTime();
-        populateCommonFields(pojo::setName, pojo::setCreatedAt, pojo::setBirthDate, pojo::setLoginTime, pojo::setSecret);
+    private JavaTimePojo buildPojo() {
+        JavaTimePojo pojo = new JavaTimePojo();
+        pojo.setName("Test User");
+        pojo.setCreatedAt(CREATED_AT);
+        pojo.setBirthDate(BIRTH_DATE);
+        pojo.setLoginTime(LOGIN_TIME);
+        pojo.setSecret("my-secret");
         return pojo;
     }
 
-    private JavaTimePojoWithNonsensitiveDateAndTime buildNonsensitivePojo() {
-        JavaTimePojoWithNonsensitiveDateAndTime pojo = new JavaTimePojoWithNonsensitiveDateAndTime();
-        populateCommonFields(pojo::setName, pojo::setCreatedAt, pojo::setBirthDate, pojo::setLoginTime, pojo::setSecret);
-        return pojo;
-    }
-
-    private void populateCommonFields(
-            Consumer<String> setName,
-            Consumer<LocalDateTime> setCreatedAt,
-            Consumer<LocalDate>     setBirthDate,
-            Consumer<LocalTime>     setLoginTime,
-            Consumer<String>        setSecret
-    ) {
-        setName.accept("Test User");
-        setCreatedAt.accept(CREATED_AT);
-        setBirthDate.accept(BIRTH_DATE);
-        setLoginTime.accept(LOGIN_TIME);
-        setSecret.accept("my-secret");
-    }
-
-    @Data @SecureLog
-    public static class JavaTimePojoWithSensitiveDateAndTime {
+    @Data
+    @SecureLog
+    public static class JavaTimePojo {
         private String name;
         @LogSensitive private LocalDateTime createdAt;
-        @LogSensitive private LocalDate     birthDate;
-        @LogSensitive private LocalTime     loginTime;
-        @LogSensitive private String        secret;
-    }
-
-    @Data @SecureLog
-    public static class JavaTimePojoWithNonsensitiveDateAndTime {
-        private String        name;
-        private LocalDateTime createdAt;
-        private LocalDate     birthDate;
-        private LocalTime     loginTime;
+        private LocalDate birthDate;
+        private LocalTime loginTime;
         @LogSensitive private String secret;
-    }
-
-    private JsonNode toNode(String json) throws JsonProcessingException {
-        return TestUtils.asJsonNode(json);
     }
 }


### PR DESCRIPTION
Added `findAndRegisterModules()` to auto-register Jackson modules like `JavaTimeModule` for Java 8 date/time serialization support.